### PR TITLE
Update MoneyTree version

### DIFF
--- a/ethereum_tree.gemspec
+++ b/ethereum_tree.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ecdsa', '~> 1.2'
   spec.add_dependency 'keccak', '~> 1.3'
   spec.add_dependency 'rlp', '~> 0.7'
-  spec.add_dependency 'money-tree', '~> 0.10'
+  spec.add_dependency 'money-tree', '~> 0.11.2'
 end


### PR DESCRIPTION
The actual used version of money tree, is a constraint. Because it requires an old version of  ruby / openssl lib.
By this upgrade we are now compatible with recent ruby version